### PR TITLE
Call State

### DIFF
--- a/metafunctions/concurrent.py
+++ b/metafunctions/concurrent.py
@@ -5,7 +5,7 @@ from multiprocessing import Queue
 import queue
 
 from metafunctions.core import FunctionMerge
-from metafunctions.core._decorators import inject_call_state
+from metafunctions.core import inject_call_state
 from metafunctions.exceptions import ConcurrentException
 
 

--- a/metafunctions/concurrent.py
+++ b/metafunctions/concurrent.py
@@ -5,6 +5,7 @@ from multiprocessing import Queue
 import queue
 
 from metafunctions.core import FunctionMerge
+from metafunctions.core._decorators import inject_call_state
 from metafunctions.exceptions import ConcurrentException
 
 
@@ -23,11 +24,11 @@ class ConcurrentMerge(FunctionMerge):
         joined_funcs = super().__str__()
         return f"concurrent{joined_funcs}"
 
+    @inject_call_state
     def __call__(self, *args, **kwargs):
         '''We fork here, and execute each function in a child process before joining the results
         with _merge_func
         '''
-        self._modify_kwargs(kwargs)
         result_q = Queue()
         error_q = Queue()
 

--- a/metafunctions/core/__init__.py
+++ b/metafunctions/core/__init__.py
@@ -4,3 +4,4 @@ from ._base import SimpleFunction
 from ._base import DeferredValue
 from ._base import FunctionChain
 from ._base import FunctionMerge
+from ._decorators import inject_call_state

--- a/metafunctions/core/__init__.py
+++ b/metafunctions/core/__init__.py
@@ -5,3 +5,4 @@ from ._base import DeferredValue
 from ._base import FunctionChain
 from ._base import FunctionMerge
 from ._decorators import inject_call_state
+from ._call_state import CallState

--- a/metafunctions/core/_base.py
+++ b/metafunctions/core/_base.py
@@ -172,6 +172,7 @@ class SimpleFunction(MetaFunction):
 
     @inject_call_state
     def __call__(self, *args, call_state, **kwargs):
+        call_state._called_functions.append(self)
         if getattr(self._function, '_receives_call_state', False):
             args = (call_state, ) + args
         try:

--- a/metafunctions/core/_base.py
+++ b/metafunctions/core/_base.py
@@ -190,12 +190,12 @@ class SimpleFunction(MetaFunction):
     def functions(self):
         return (self._function, )
 
-    def _handle_exception(self, meta, e):
+    def _handle_exception(self, call_state, e):
         if self.add_location_to_traceback:
             from metafunctions.util import highlight_current_function
             detailed_message = str(e)
-            if meta:
-                detailed_message = f"{str(e)} \n\nOccured in the following function: {highlight_current_function(meta)}"
+            if call_state:
+                detailed_message = f"{str(e)} \n\nOccured in the following function: {highlight_current_function(call_state)}"
             raise type(e)(detailed_message).with_traceback(e.__traceback__)
         raise
 

--- a/metafunctions/core/_base.py
+++ b/metafunctions/core/_base.py
@@ -185,7 +185,7 @@ class SimpleFunction(MetaFunction):
             self._handle_exception(call_state, e)
 
     def __repr__(self):
-        return f'{self.__class__.__name__}({self.functions[0]})'
+        return f'{self.__class__.__name__}({self.functions[0]!r})'
 
     def __str__(self):
         try:
@@ -218,6 +218,9 @@ class DeferredValue(SimpleFunction):
 
     def __call__(self, *args, **kwargs):
         return self._value
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self._value!r})'
 
     @property
     def functions(self):

--- a/metafunctions/core/_base.py
+++ b/metafunctions/core/_base.py
@@ -6,6 +6,7 @@ import functools
 
 from metafunctions.core._decorators import binary_operation
 from metafunctions.core._decorators import inject_call_state
+from metafunctions.core._call_state import CallState
 
 
 class MetaFunction(metaclass=abc.ABCMeta):
@@ -40,7 +41,7 @@ class MetaFunction(metaclass=abc.ABCMeta):
 
     @staticmethod
     def new_call_state():
-        return {}
+        return CallState()
 
     ### Operator overloads ###
     @binary_operation

--- a/metafunctions/core/_call_state.py
+++ b/metafunctions/core/_call_state.py
@@ -3,9 +3,11 @@ class CallState:
     __slots__ = (
         'data',
         '_called_functions',
+        '_meta_entry'
     )
     def __init__(self):
         '''An object for holding state during a metafunction call.
         '''
         self.data = {}
         self._called_functions = []
+        self._meta_entry = None

--- a/metafunctions/core/_call_state.py
+++ b/metafunctions/core/_call_state.py
@@ -1,0 +1,11 @@
+
+class CallState:
+    __slots__ = (
+        'data',
+        '_called_functions',
+    )
+    def __init__(self):
+        '''An object for holding state during a metafunction call.
+        '''
+        self.data = {}
+        self._called_functions = []

--- a/metafunctions/core/_decorators.py
+++ b/metafunctions/core/_decorators.py
@@ -18,10 +18,14 @@ def binary_operation(method):
 
 
 def inject_call_state(call_method):
-    '''Decorates the call method to insure call_state is present in kwargs, or create a new one.'''
+    '''Decorates the call method to insure call_state is present in kwargs, or create a new one.
+    If the call state doesn't have a meta entry point set, we assume we are the meta entry point.
+    '''
     @wraps(call_method)
     def with_call_state(self, *args, **kwargs):
-        kwargs.setdefault('call_state', self.new_call_state())
+        call_state = kwargs.setdefault('call_state', self.new_call_state())
+        if call_state._meta_entry is None:
+            call_state._meta_entry = self
         return call_method(self, *args, **kwargs)
     return with_call_state
 

--- a/metafunctions/core/_decorators.py
+++ b/metafunctions/core/_decorators.py
@@ -1,13 +1,13 @@
 '''
 Internal decorators that are applied to MetaFunction methods, not functions.
 '''
-import functools
+from functools import wraps
 from collections.abc import Callable
 
 
 def binary_operation(method):
     '''Internal decorator to apply common type checking for binary operations'''
-    @functools.wraps(method)
+    @wraps(method)
     def binary_operation(self, other):
         if isinstance(other, Callable):
             new_other = self.make_meta(other)
@@ -17,17 +17,12 @@ def binary_operation(method):
     return binary_operation
 
 
-#def link_child_functions(call_method):
-    #'''
-    #Internal deocrator to initialize links to child functions pre-call, and remove them
-    #post-call.
-    #'''
-    #@functools.wraps(call_method)
-    #def new_call(self, *args, **kwargs):
-        ##call link on each child function
-        #for f in self.functions:
-            #try:
-
-        #pass
+def inject_call_state(call_method):
+    '''Decorates the call method to insure call_state is present in kwargs, or create a new one.'''
+    @wraps(call_method)
+    def with_call_state(self, *args, **kwargs):
+        kwargs.setdefault('call_state', self.new_call_state())
+        return call_method(self, *args, **kwargs)
+    return with_call_state
 
 

--- a/metafunctions/tests/test_call_state.py
+++ b/metafunctions/tests/test_call_state.py
@@ -1,0 +1,7 @@
+
+from metafunctions.tests.util import BaseTestCase
+
+
+class TestUnit(BaseTestCase):
+    def test_(self):
+        self.fail()

--- a/metafunctions/tests/test_call_state.py
+++ b/metafunctions/tests/test_call_state.py
@@ -28,7 +28,6 @@ class TestUnit(BaseTestCase):
         fg = f | g | h
         self.assertEqual(fg('_'), '_fgb')
 
-
     def test_provide_call_state(self):
         # A call state you provide is passed to all functions
         @node

--- a/metafunctions/tests/test_call_state.py
+++ b/metafunctions/tests/test_call_state.py
@@ -1,7 +1,52 @@
 
 from metafunctions.tests.util import BaseTestCase
+from metafunctions.util import bind_call_state
+from metafunctions.util import node
+from metafunctions.core import CallState
 
 
 class TestUnit(BaseTestCase):
-    def test_(self):
-        self.fail()
+    def test_bind_call_state(self):
+        # Bound functions receive call state
+        @node
+        @bind_call_state
+        def f(call_state, x):
+            self.assertIsInstance(call_state, CallState)
+            call_state.data['h'] = 'b'
+            return x + 'f'
+
+        @node
+        def g(x):
+            return x + 'g'
+
+        @node
+        @bind_call_state
+        def h(call_state, x):
+            self.assertIsInstance(call_state, CallState)
+            return x + call_state.data['h']
+
+        fg = f | g | h
+        self.assertEqual(fg('_'), '_fgb')
+
+
+    def test_provide_call_state(self):
+        # A call state you provide is passed to all functions
+        @node
+        @bind_call_state
+        def f(call_state, x):
+            self.assertIs(call_state, c)
+            call_state.data['h'] = 'd'
+            return x + 'f'
+        @node
+        def g(x):
+            return x + 'g'
+        @node
+        @bind_call_state
+        def h(call_state, x):
+            self.assertIs(call_state, c)
+            return x + call_state.data['h']
+        fg = f | g | h
+
+        c = CallState()
+        self.assertEqual(fg('_', call_state=c), '_fgd')
+

--- a/metafunctions/tests/test_concurrent.py
+++ b/metafunctions/tests/test_concurrent.py
@@ -7,6 +7,7 @@ import colors
 
 from metafunctions.tests.util import BaseTestCase
 from metafunctions.util import node
+from metafunctions.util import bind_call_state
 from metafunctions.util import highlight_current_function
 from metafunctions.util import concurrent
 from metafunctions.concurrent import ConcurrentMerge
@@ -41,25 +42,32 @@ class TestUnit(BaseTestCase):
         '''
         Every function in the pipeline recieves the same meta.
         '''
+        @node
+        @bind_call_state
+        def f(call_state, x):
+            self.assertIs(call_state._meta_entry, cmp)
+            return 1
         @node()
-        def f(meta, x):
-            self.assertIs(meta, cmp)
+        @bind_call_state
+        def g(call_state, x):
+            self.assertIs(call_state._meta_entry, cmp)
             return 1
         @node
-        def g(meta, x):
-            self.assertIs(meta, cmp)
+        @bind_call_state
+        def h(call_state, x):
+            self.assertIs(call_state._meta_entry, cmp)
             return 1
         @node
-        def h(meta, x):
-            self.assertIs(meta, cmp)
-            return 1
-        @node
-        def i(meta, x):
-            self.assertIs(meta, cmp)
+        @bind_call_state
+        def i(call_state, x):
+            self.assertIs(call_state._meta_entry, cmp)
             return 1
 
         cmp = ConcurrentMerge(h + f + f / h + i - g)
         self.assertEqual(cmp(1), 3)
+
+        self.assertEqual(cmp(1, call_state=cmp.new_call_state()), 3)
+
         # how do pretty tracebacks work in multiprocessing?
 
     def test_concurrent(self):

--- a/metafunctions/tests/test_concurrent.py
+++ b/metafunctions/tests/test_concurrent.py
@@ -41,19 +41,19 @@ class TestUnit(BaseTestCase):
         '''
         Every function in the pipeline recieves the same meta.
         '''
-        @node(bind=True)
+        @node()
         def f(meta, x):
             self.assertIs(meta, cmp)
             return 1
-        @node(bind=True)
+        @node
         def g(meta, x):
             self.assertIs(meta, cmp)
             return 1
-        @node(bind=True)
+        @node
         def h(meta, x):
             self.assertIs(meta, cmp)
             return 1
-        @node(bind=True)
+        @node
         def i(meta, x):
             self.assertIs(meta, cmp)
             return 1

--- a/metafunctions/tests/test_pipe.py
+++ b/metafunctions/tests/test_pipe.py
@@ -201,8 +201,9 @@ class TestIntegration(BaseTestCase):
         @node
         def f(x='F'):
             return x + 'f'
-        @node()
-        def g(meta, x='G'):
+        @node
+        @bind_call_state
+        def g(call_state, x='G'):
             return x + 'g'
 
         cmp = f | g | f + g

--- a/metafunctions/tests/test_pipe.py
+++ b/metafunctions/tests/test_pipe.py
@@ -167,25 +167,32 @@ class TestIntegration(BaseTestCase):
         '''
         Every function in the pipeline recieves the same meta.
         '''
-        @node(bind=True)
-        def f(meta, x):
-            self.assertIs(meta, cmp)
+        @node
+        @bind_call_state
+        def f(call_state, x):
+            self.assertIs(call_state._meta_entry, cmp)
             return 1
-        @node(bind=True)
-        def g(meta, x):
-            self.assertIs(meta, cmp)
+        @node()
+        @bind_call_state
+        def g(call_state, x):
+            self.assertIs(call_state._meta_entry, cmp)
             return 1
-        @node(bind=True)
-        def h(meta, x):
-            self.assertIs(meta, cmp)
+        @node
+        @bind_call_state
+        def h(call_state, x):
+            self.assertIs(call_state._meta_entry, cmp)
             return 1
-        @node(bind=True)
-        def i(meta, x):
-            self.assertIs(meta, cmp)
+        @node
+        @bind_call_state
+        def i(call_state, x):
+            self.assertIs(call_state._meta_entry, cmp)
             return 1
 
         cmp = f | g | i | h + f + f / h + i - g
         self.assertEqual(cmp(1), 3)
+
+        #this works if we provide our own call_state too.
+        self.assertEqual(cmp(1, call_state=CallState()), 3)
 
     def test_defaults(self):
         '''
@@ -194,7 +201,7 @@ class TestIntegration(BaseTestCase):
         @node
         def f(x='F'):
             return x + 'f'
-        @node(bind=True)
+        @node()
         def g(meta, x='G'):
             return x + 'g'
 
@@ -223,7 +230,7 @@ class TestIntegration(BaseTestCase):
         # everything still work (as long as the decorated function gets upgraded to a metafunction.
         # consider a @metadecorator decorator to facilitate this).
 
-        @node(bind=True)
+        @node()
         def f(meta, x):
             self.assertIs(meta, abcf)
             return x + 'f'

--- a/metafunctions/tests/test_pipe.py
+++ b/metafunctions/tests/test_pipe.py
@@ -4,7 +4,9 @@ import functools
 
 from metafunctions.tests.util import BaseTestCase
 from metafunctions.util import node
+from metafunctions.util import bind_call_state
 from metafunctions.util import highlight_current_function
+from metafunctions.core import CallState
 
 
 class TestIntegration(BaseTestCase):
@@ -123,17 +125,18 @@ class TestIntegration(BaseTestCase):
         Parent refers to the parent MetaFunction.
         '''
 
-        @node(bind=True)
-        def parent_test(meta, x):
-            return meta
+        @node
+        @bind_call_state
+        def parent_test(call_state, x):
+            return call_state
 
         ab = a | b
         abc = ab + c
         abc_ = abc | parent_test
 
-        meta = abc_('_')
-        self.assertIs(abc_, meta)
-        self.assertListEqual(meta._called_functions, [a, b, c, parent_test])
+        call_state = abc_('_')
+        self.assertIsInstance(call_state, CallState)
+        self.assertListEqual(call_state._called_functions, [a, b, c, parent_test])
 
     @mock.patch('metafunctions.util.highlight_current_function')
     def test_pretty_exceptions(self, mock_h):

--- a/metafunctions/tests/test_pipe.py
+++ b/metafunctions/tests/test_pipe.py
@@ -226,12 +226,11 @@ class TestIntegration(BaseTestCase):
         with self.assertRaises(ValueError) as e:
             numeric(2)
 
-    @unittest.skip('this is a TODO')
     def test_decoration(self):
         # It should be possible to decorate a metafunction with another metafunction and have
-        # everything still work (as long as the decorated function gets upgraded to a metafunction.
-        # consider a @metadecorator decorator to facilitate this).
-
+        # everything still work (as long as the decorated function gets upgraded to a metafunction).
+        # I don't think this is something that will happen, but I want to enforce that it is
+        # possible, for purposes of conceptual purity.
         @node()
         @bind_call_state
         def f(call_state, x):
@@ -239,6 +238,7 @@ class TestIntegration(BaseTestCase):
             return x + 'f'
 
         fn = node(f+'sup')
+        repr(fn)
         abcf = a | b | c | fn
 
         self.assertEqual(abcf('_'), '_abcfsup')

--- a/metafunctions/tests/test_pipe.py
+++ b/metafunctions/tests/test_pipe.py
@@ -226,14 +226,16 @@ class TestIntegration(BaseTestCase):
         with self.assertRaises(ValueError) as e:
             numeric(2)
 
+    @unittest.skip('this is a TODO')
     def test_decoration(self):
         # It should be possible to decorate a metafunction with another metafunction and have
         # everything still work (as long as the decorated function gets upgraded to a metafunction.
         # consider a @metadecorator decorator to facilitate this).
 
         @node()
-        def f(meta, x):
-            self.assertIs(meta, abcf)
+        @bind_call_state
+        def f(call_state, x):
+            self.assertIs(call_state._meta_entry, abcf)
             return x + 'f'
 
         fn = node(f+'sup')

--- a/metafunctions/tests/test_pipe.py
+++ b/metafunctions/tests/test_pipe.py
@@ -230,6 +230,26 @@ class TestIntegration(BaseTestCase):
 
         self.assertEqual(abcf('_'), '_abcfsup')
 
+    def test_kwargs(self):
+        #Kwargs are passed to all functions
+
+        @node
+        def k(x, k='k'):
+            return x + k
+
+        self.assertEqual(k('_'), '_k')
+        self.assertEqual(k('_', k='_'), '__')
+
+        kk = k + k
+        self.assertEqual(kk('_'), '_k_k')
+        self.assertEqual(kk('_', k='_'), '____')
+
+        klen = k | len
+        self.assertEqual(klen('_'), 2)
+        with self.assertRaises(TypeError):
+            #passing a kwarg to len causes an error
+            klen('_', k=5)
+
     def test_recursion(self):
         # Recursion should work with bind. how?
         self.fail('thinking')

--- a/metafunctions/tests/test_pipe.py
+++ b/metafunctions/tests/test_pipe.py
@@ -238,7 +238,8 @@ class TestIntegration(BaseTestCase):
             return x + 'f'
 
         fn = node(f+'sup')
-        repr(fn)
+        self.assertEqual(repr(fn), f"SimpleFunction({(f+'sup')!r})")
+        self.assertEqual(str(fn), "(f + 'sup')")
         abcf = a | b | c | fn
 
         self.assertEqual(abcf('_'), '_abcfsup')

--- a/metafunctions/tests/test_pipe.py
+++ b/metafunctions/tests/test_pipe.py
@@ -235,15 +235,6 @@ class TestIntegration(BaseTestCase):
         self.fail('thinking')
 
 
-    def test_detect_position(self):
-        #metafunctions know if they are top or bottom level
-
-        # A metafunction will never change from top level to bottom level, but a simplefunction
-        # isn't guaranted to be at the bottom
-
-        # If we're the outermost function, we need to provide ourself as meta
-
-        self.fail('Why do I need this again?')
 
 
 ### Simple Sample Functions ###

--- a/metafunctions/tests/test_util.py
+++ b/metafunctions/tests/test_util.py
@@ -2,7 +2,7 @@ from unittest import mock
 import functools
 
 from metafunctions.tests.util import BaseTestCase
-from metafunctions.util import store, recall, node, highlight_current_function
+from metafunctions.util import store, recall, node, highlight_current_function, bind_call_state
 from metafunctions.core import MetaFunction, SimpleFunction
 
 
@@ -12,14 +12,16 @@ class TestUnit(BaseTestCase):
         If decorated with bind_call_state, the function receives the call state dictionary as its
         first argument.
         '''
-        @node(bind=True)
-        def a_(meta, x):
-            self.assertIsInstance(meta, MetaFunction)
-            meta.data['a'] = 'b'
+        @node
+        @bind_call_state
+        def a_(call_state, x):
+            self.assertIsInstance(call_state, dict)
+            call_state['a'] = 'b'
             return x + 'a'
-        @node(bind=True)
-        def f(meta, x):
-            return x + meta.data.get('a', 'f')
+        @node
+        @bind_call_state
+        def f(call_state, x):
+            return x + call_state.get('a', 'f')
 
         self.assertEqual(a('_'), '_a')
         self.assertEqual(f('_'), '_f')

--- a/metafunctions/tests/test_util.py
+++ b/metafunctions/tests/test_util.py
@@ -7,13 +7,10 @@ from metafunctions.core import MetaFunction, SimpleFunction
 
 
 class TestUnit(BaseTestCase):
-    def test_node_bind(self):
+    def test_bind_call_state(self):
         '''
-        Node bind rules:
-        The MetaFunction recieved in a base function when bind is true is the
-        function that was called. E.g., if a SimpleFunction is called directly, meta will be that
-        SimpleFunction itself. However, if the SimpleFunction is contained within a hierarchy of
-        other MetaFunction, meta will be the highest level (i.e., outermost) Metafunction.
+        If decorated with bind_call_state, the function receives the call state dictionary as its
+        first argument.
         '''
         @node(bind=True)
         def a_(meta, x):

--- a/metafunctions/util.py
+++ b/metafunctions/util.py
@@ -38,8 +38,12 @@ def node(_func=None, *, modify_tracebacks=True):
 
 
 def bind_call_state(func):
-    func._receives_call_state = True
-    return func
+    @functools.wraps(func)
+    def provides_call_state(*args, **kwargs):
+        call_state = kwargs.pop('call_state')
+        return func(call_state, *args, **kwargs)
+    provides_call_state._receives_call_state = True
+    return provides_call_state
 
 
 def store(key):

--- a/metafunctions/util.py
+++ b/metafunctions/util.py
@@ -37,6 +37,12 @@ def node(_func=None, *, bind=False, modify_tracebacks=True):
     return decorator(_func)
 
 
+def bind_call_state(_func):
+    def call_state_provider(*args, **kwargs):
+        call_state = kwargs.pop('call_state')
+        return _func(call_state, *args)
+
+
 def store(key):
     '''Store the received output in the meta data dictionary under the given key.'''
     @node(bind=True)

--- a/metafunctions/util.py
+++ b/metafunctions/util.py
@@ -92,16 +92,16 @@ def _system_supports_color():
     return True
 
 
-def highlight_current_function(meta, color=colors.red, use_color=_system_supports_color()):
-    '''Return a formatted string showing the location of the currently active function in meta.
+def highlight_current_function(call_state, color=colors.red, use_color=_system_supports_color()):
+    '''Return a formatted string showing the location of the currently active function in call_state.
 
     Consider this a 'you are here' when called from within a function pipeline.
     '''
-    current_name = str(meta._called_functions[-1])
+    current_name = str(call_state._called_functions[-1])
 
-    # how many times will current_name appear in str(meta)?
+    # how many times will current_name appear in str(call_state._meta_entry)?
     # Bearing in mind that pervious function names may contain current_name
-    num_occurences = sum(str(f).count(current_name) for f in meta._called_functions)
+    num_occurences = sum(str(f).count(current_name) for f in call_state._called_functions)
 
     # There's probably a better regex for this.
     skip = f'.*{current_name}'
@@ -111,7 +111,7 @@ def highlight_current_function(meta, color=colors.red, use_color=_system_support
     if use_color:
         highlighted_name = color(highlighted_name)
 
-    highlighted_string = re.sub(regex, fr'\1{highlighted_name}\2', str(meta))
+    highlighted_string = re.sub(regex, fr'\1{highlighted_name}\2', str(call_state._meta_entry))
     return highlighted_string
 
 

--- a/metafunctions/util.py
+++ b/metafunctions/util.py
@@ -13,34 +13,32 @@ from metafunctions.core import FunctionMerge
 from metafunctions.concurrent import ConcurrentMerge
 
 
-def node(_func=None, *, bind=False, modify_tracebacks=True):
+def node(_func=None, *, modify_tracebacks=True):
     '''Turn the decorated function into a MetaFunction.
 
     Args:
         _func: Internal use. This will be the decorated function if node is used as a decorator
         with no params.
-        bind: If True, the MetaFunction object is passed to the function as its first parameter.
         modify_tracebacks: If true, exceptions raised in composed functions have a string appended
         to them describing the location of the function in the function chain.
 
     Usage:
 
-    @node(bind=True)
-    def f(metafunc, x):
+    @node
+    def f(x):
        <do something cool>
     '''
     def decorator(function):
-        newfunc = SimpleFunction(function, bind, modify_tracebacks)
+        newfunc = SimpleFunction(function, modify_tracebacks)
         return newfunc
     if not _func:
         return decorator
     return decorator(_func)
 
 
-def bind_call_state(_func):
-    def call_state_provider(*args, **kwargs):
-        call_state = kwargs.pop('call_state')
-        return _func(call_state, *args)
+def bind_call_state(func):
+    func._receives_call_state = True
+    return func
 
 
 def store(key):

--- a/metafunctions/util.py
+++ b/metafunctions/util.py
@@ -10,6 +10,7 @@ import colors
 from metafunctions.core import MetaFunction
 from metafunctions.core import SimpleFunction
 from metafunctions.core import FunctionMerge
+from metafunctions.core import CallState
 from metafunctions.concurrent import ConcurrentMerge
 
 
@@ -43,23 +44,25 @@ def bind_call_state(func):
 
 def store(key):
     '''Store the received output in the meta data dictionary under the given key.'''
-    @node(bind=True)
-    def store(meta, val):
-        meta.data[key] = val
+    @node
+    @bind_call_state
+    def store(call_state, val):
+        call_state.data[key] = val
         return val
     store.__name__ = f"store('{key}')"
     return store
 
 
-def recall(key, from_meta:MetaFunction=None):
-    '''Retrieve the given key from the meta data dictionary. Optionally, use `from_meta` to specify
-    a different metafunction than the current one.
+def recall(key, from_call_state:CallState=None):
+    '''Retrieve the given key from the meta data dictionary. Optionally, use `from_call_state` to
+    specify a different call_state than the current one.
     '''
-    @node(bind=True)
-    def recall(meta, val):
-        if from_meta:
-            return from_meta.data[key]
-        return meta.data[key]
+    @node
+    @bind_call_state
+    def recall(call_state, val):
+        if from_call_state:
+            return from_call_state.data[key]
+        return call_state.data[key]
     recall.__name__ = f"recall('{key}')"
     return recall
 


### PR DESCRIPTION
This replaces binding `meta` with a `CallState` instance. Call state is just a container for recording information about a current call. You can use the `bind_call_state` decorator to cause your function to receive the call_state object as its first parameter. You can also provide your own `CallState` when you call a MetaFunction, if you'd like access to it after the call. 