### PR TITLE
And operator

### DIFF
--- a/metafunctions/core/_base.py
+++ b/metafunctions/core/_base.py
@@ -7,6 +7,7 @@ import functools
 from metafunctions.core._decorators import binary_operation
 from metafunctions.core._decorators import inject_call_state
 from metafunctions.core._call_state import CallState
+from metafunctions.operators import concat
 
 
 class MetaFunction(metaclass=abc.ABCMeta):
@@ -57,11 +58,11 @@ class MetaFunction(metaclass=abc.ABCMeta):
 
     @binary_operation
     def __and__(self, other):
-        return FunctionMerge.combine
+        return FunctionMerge.combine(concat, self, other)
 
     @binary_operation
     def __rand__(self, other):
-        pass
+        return FunctionMerge.combine(concat, other, self)
 
     @binary_operation
     def __add__(self, other):
@@ -137,6 +138,7 @@ class FunctionMerge(MetaFunction):
         '-': operator.sub,
         '*': operator.mul,
         '/': operator.truediv,
+        '&': concat,
     }
     _operator_to_character = {v: k for k, v in _character_to_operator.items()}
 

--- a/metafunctions/core/_base.py
+++ b/metafunctions/core/_base.py
@@ -46,6 +46,18 @@ class MetaFunction(metaclass=abc.ABCMeta):
     def new_call_state():
         return CallState()
 
+    @classmethod
+    def combine(cls, *funcs):
+        '''Merge chains; i.e., combine all FunctionChains in `funcs` into a single FunctionChain.
+        '''
+        new_funcs = []
+        for f in funcs:
+            if isinstance(f, cls):
+                new_funcs.extend(f.functions)
+            else:
+                new_funcs.append(f)
+        return cls(tuple(new_funcs))
+
     ### Operator overloads ###
     @binary_operation
     def __or__(self, other):
@@ -103,18 +115,6 @@ class FunctionChain(MetaFunction):
         '''
         super().__init__()
         self._functions = functions
-
-    @classmethod
-    def combine(cls, *funcs):
-        '''Merge chains; i.e., combine all FunctionChains in `funcs` into a single FunctionChain.
-        '''
-        new_funcs = []
-        for f in funcs:
-            if isinstance(f, FunctionChain):
-                new_funcs.extend(f.functions)
-            else:
-                new_funcs.append(f)
-        return cls(tuple(new_funcs))
 
     @inject_call_state
     def __call__(self, *args, **kwargs):
@@ -201,6 +201,13 @@ class SimpleFunction(MetaFunction):
             # We're usually wrapping a function, but it's possible we're wrapping another
             # metafunction
             return str(self.functions[0])
+
+    @classmethod
+    def combine(cls, *funcs):
+        '''SimpleFunctions cannot be combined'''
+        raise NotImplementedError((
+                f'combine on {cls.__name__} is not implemented. '
+                f'You should use another MetaFunction to join {cls.__name__}s'))
 
     @property
     def functions(self):

--- a/metafunctions/core/_base.py
+++ b/metafunctions/core/_base.py
@@ -56,6 +56,14 @@ class MetaFunction(metaclass=abc.ABCMeta):
         return FunctionChain.combine(other, self)
 
     @binary_operation
+    def __and__(self, other):
+        pass
+
+    @binary_operation
+    def __rand__(self, other):
+        pass
+
+    @binary_operation
     def __add__(self, other):
         return FunctionMerge(operator.add, (self, other))
 
@@ -172,7 +180,6 @@ class SimpleFunction(MetaFunction):
         super().__init__()
         self._function = function
         self.add_location_to_traceback = print_location_in_traceback
-
 
     @inject_call_state
     def __call__(self, *args, call_state, **kwargs):

--- a/metafunctions/operators.py
+++ b/metafunctions/operators.py
@@ -1,0 +1,7 @@
+'''
+Extra operators used by MetaFunctions
+'''
+
+def concat(*args):
+    "concat(1, 2, 3) -> (1, 2, 3)"
+    return args

--- a/metafunctions/tests/test_function_merge.py
+++ b/metafunctions/tests/test_function_merge.py
@@ -32,7 +32,14 @@ class TestUnit(BaseTestCase):
         d = FunctionMerge(concat, (b, b), join_str='q')
         self.assertEqual(str(d), '(b q b)')
 
+    def test_join(self):
+        # The first real non-binary function! Like the example above.
 
+        cmp = a & a & 'sweet as'
+
+        self.assertTupleEqual(cmp('_'), ('_a', '_a', 'sweet as'))
+        self.assertEqual(str(cmp), "(a & a & 'sweet as')")
+        self.assertEqual(repr(cmp), f"FunctionMerge()")
 
 @SimpleFunction
 def a(x):

--- a/metafunctions/tests/test_function_merge.py
+++ b/metafunctions/tests/test_function_merge.py
@@ -3,6 +3,7 @@ import operator
 from metafunctions.core import FunctionMerge
 from metafunctions.core import SimpleFunction
 from metafunctions.tests.util import BaseTestCase
+from metafunctions.operators import concat
 
 
 class TestUnit(BaseTestCase):
@@ -39,7 +40,7 @@ class TestUnit(BaseTestCase):
 
         self.assertTupleEqual(cmp('_'), ('_a', '_a', 'sweet as'))
         self.assertEqual(str(cmp), "(a & a & 'sweet as')")
-        self.assertEqual(repr(cmp), f"FunctionMerge()")
+        self.assertEqual(repr(cmp), f"FunctionMerge({concat}, {(a, a, cmp._functions[-1])})")
 
     def test_combine(self):
         # Only combine FunctionMerges that have the same MergeFunc

--- a/metafunctions/tests/test_function_merge.py
+++ b/metafunctions/tests/test_function_merge.py
@@ -42,6 +42,11 @@ class TestUnit(BaseTestCase):
         self.assertEqual(str(cmp), "(a & a & 'sweet as')")
         self.assertEqual(repr(cmp), f"FunctionMerge({concat}, {(a, a, cmp._functions[-1])})")
 
+        #__rand__ works too
+        a = 'sweet as' & a
+        self.assertEqual(a('+'), ('sweet as', '+a'))
+
+
     def test_combine(self):
         # Only combine FunctionMerges that have the same MergeFunc
         add = a + b

--- a/metafunctions/tests/test_function_merge.py
+++ b/metafunctions/tests/test_function_merge.py
@@ -43,8 +43,8 @@ class TestUnit(BaseTestCase):
         self.assertEqual(repr(cmp), f"FunctionMerge({concat}, {(a, a, cmp._functions[-1])})")
 
         #__rand__ works too
-        a = 'sweet as' & a
-        self.assertEqual(a('+'), ('sweet as', '+a'))
+        a_ = 'sweet as' & a
+        self.assertEqual(a_('+'), ('sweet as', '+a'))
 
 
     def test_combine(self):

--- a/metafunctions/tests/test_simple_function.py
+++ b/metafunctions/tests/test_simple_function.py
@@ -15,11 +15,6 @@ class TestUnit(BaseTestCase):
         self.assertEqual(repr(a), f'SimpleFunction({repr(a._function)})')
         self.assertEqual(str(a), 'a')
 
-    def test_combine(self):
-        # SimpleFunctions have no combine
-        with self.assertRaises(NotImplementedError):
-            SimpleFunction.combine()
-
 
 @SimpleFunction
 def a(x):

--- a/metafunctions/tests/test_simple_function.py
+++ b/metafunctions/tests/test_simple_function.py
@@ -15,6 +15,11 @@ class TestUnit(BaseTestCase):
         self.assertEqual(repr(a), f'SimpleFunction({repr(a._function)})')
         self.assertEqual(str(a), 'a')
 
+    def test_combine(self):
+        # SimpleFunctions have no combine
+        with self.assertRaises(NotImplementedError):
+            SimpleFunction.combine()
+
 
 @SimpleFunction
 def a(x):


### PR DESCRIPTION
Add `&`:

```python
>>> cmp = func1 & func2 & 'sweet as'
>>> cmp(x)
(result1, result2, 'sweet as')
```