### PR TITLE
Merge call signature

### DIFF
--- a/metafunctions/core/_base.py
+++ b/metafunctions/core/_base.py
@@ -192,13 +192,13 @@ class FunctionMerge(MetaFunction):
         results = []
         # Note that args_iter appears first in the zip. This is because I know its len is <=
         # len(func_iter) (I asserted so above). In zip, if the first iterator is longer than the
-        # second, the first will be advanced one extra time (because zip has already called next()
-        # the first iterator before discovering that the second has been exhausted.)
+        # second, the first will be advanced one extra time, because zip has already called next()
+        # on the first iterator before discovering that the second has been exhausted.
         for arg, f in zip(args_iter, func_iter):
-            results.append(f(arg))
+            results.append(f(arg, **kwargs))
 
         #Any extra functions are called with no input
-        results.extend([f() for f in func_iter])
+        results.extend([f(**kwargs) for f in func_iter])
         return self._merge_func(*results)
 
     def __repr__(self):

--- a/metafunctions/core/_base.py
+++ b/metafunctions/core/_base.py
@@ -183,7 +183,7 @@ class FunctionMerge(MetaFunction):
         args_iter = iter(args)
         func_iter = iter(self.functions)
         if len(args) > len(self.functions):
-            raise exceptions.CompositionError(
+            raise exceptions.CallError(
                     f'{self} takes 1 or <= {len(self.functions)} '
                     f'arguments, but {len(args)} were given')
         if len(args) == 1:

--- a/metafunctions/core/_base.py
+++ b/metafunctions/core/_base.py
@@ -166,11 +166,24 @@ class FunctionMerge(MetaFunction):
     _operator_to_character = {v: k for k, v in _character_to_operator.items()}
 
     def __init__(self, merge_func:tp.Callable, functions:tuple, function_join_str=''):
-        '''A FunctionMerge merges its functions by executing all of them and passing their results to `merge_func`
+        '''
+        A FunctionMerge merges its functions by executing all of them and passing their results to
+        `merge_func`.
+
+        Behaviour of __call__:
+
+        FunctionMerge does not pass all positional arguments to all of its functions. Rather, given
+        `f=FunctionMerge()` when f is called with `f(*args)`,
+
+        * if len(args) == 1, each component function is called with args[0]
+        * if len(args) > 1 <= len(functions), function n is called with arg n. Any remaining
+        functions after all args have been exhausted are called with no args.
+        * if len(args) < len(functions), a MetaFunction CallError is raised.
 
         Args:
             function_join_str: If you're using a `merge_func` that is not one of the standard operator
-            functions, use this argument to provide a custom character to use in string formatting. If not provided, we default to using str(merge_func).
+            functions, use this argument to provide a custom character to use in string formatting. If
+            not provided, we default to using str(merge_func).
         '''
         super().__init__()
         self._merge_func = merge_func

--- a/metafunctions/exceptions.py
+++ b/metafunctions/exceptions.py
@@ -5,3 +5,6 @@ class MetaFunctionError(Exception):
 
 class ConcurrentException(MetaFunctionError):
     pass
+
+class CompositionError(MetaFunctionError, TypeError):
+    pass

--- a/metafunctions/exceptions.py
+++ b/metafunctions/exceptions.py
@@ -7,4 +7,9 @@ class ConcurrentException(MetaFunctionError):
     pass
 
 class CompositionError(MetaFunctionError, TypeError):
+    "An exception that occureds when MetaFunctions are composed incorrectly"
+    pass
+
+class CallError(MetaFunctionError, TypeError):
+    "An exception that occures when a MetaFunction is called incorrectly"
     pass

--- a/metafunctions/tests/test_function_merge.py
+++ b/metafunctions/tests/test_function_merge.py
@@ -4,6 +4,7 @@ from metafunctions.core import FunctionMerge
 from metafunctions.core import SimpleFunction
 from metafunctions.tests.util import BaseTestCase
 from metafunctions.operators import concat
+from metafunctions import exceptions
 
 
 class TestUnit(BaseTestCase):
@@ -16,7 +17,7 @@ class TestUnit(BaseTestCase):
         c = FunctionMerge(operator.add, (a, b))
         self.assertEqual(c('_'), '_a_b')
         self.assertEqual(c('-', '_'), '-a_b')
-        with self.assertRaises(TypeError):
+        with self.assertRaises(exceptions.CallError):
             c('_', '_', '_')
 
         @SimpleFunction

--- a/metafunctions/tests/test_function_merge.py
+++ b/metafunctions/tests/test_function_merge.py
@@ -15,13 +15,22 @@ class TestUnit(BaseTestCase):
     def test_call(self):
         c = FunctionMerge(operator.add, (a, b))
         self.assertEqual(c('_'), '_a_b')
+        self.assertEqual(c('-', '_'), '-a_b')
+        with self.assertRaises(TypeError):
+            c('_', '_', '_')
+
+        @SimpleFunction
+        def d():
+            return 'd'
+        abd = a & b & d
+        self.assertEqual(abd('-', '_'), ('-a', '_b', 'd'))
+
 
     def test_format(self):
         c = FunctionMerge(operator.add, (a, b), function_join_str='tacos')
         self.assertEqual(str(c), '(a tacos b)')
 
     def test_non_binary(self):
-        # I don't currently have any non binary functionMerges, but they're designed to be possible
         def concat(*args):
             return ''.join(args)
 


### PR DESCRIPTION
# What
This changes the call signature of `FunctionMerge`.

Given `cmp = a + b`, where `a` and `b` are functions:

Previously `cmp(1, 2)` would call both a and b with `1` and `2` as positional args 
(i.e, `a(1, 2) + b(1, 2)`). 

Now `cmp(1, 2)` is equivalent to `a(1) + b(2)`. The rules for doing this are explained in the FunctionMerge docstring. 

# Why
This change increases the complexity of FunctionMerge somewhat, and has the potential to be less intuitive than the previous behaviour of simply passing all input to all functions. However, it's the simplest way I've come up with to facilitate some of the advanced use cases of `concurrent`, e.g., calling multiple functions in parallel with different input and combining the results. The old behaviour is still attainable by passing multiple arguments as a tuple, and using `star` to unpack them into individual functions: 

```python
cmp = (star(a) + star(b)) 
cmp((1, 2))
```