### PR TITLE
Concurrent call state

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,4 @@
 [run]
 branch = True
 omit = */tests/*
+parallel = True

--- a/metafunctions/concurrent.py
+++ b/metafunctions/concurrent.py
@@ -69,7 +69,7 @@ class ConcurrentMerge(FunctionMerge):
                 raise exceptions.ConcurrentException(
                         'Caught exception in child process') from pickle.loads(r.exception)
             kwargs['call_state'].data.update(pickle.loads(r.call_state_data))
-            results.append(r.result)
+            results.append(pickle.loads(r.result))
         return self._merge_func(*results)
 
     def _get_call_iterators(self, args):
@@ -99,9 +99,10 @@ class ConcurrentMerge(FunctionMerge):
         try:
             r = self._call_function(func, args, kwargs)
 
-            #pickle data here, so that we can't crash with pickle errors in the finally clause
+            #pickle here, so that we can't crash with pickle errors in the finally clause
+            pickled_r = pickle.dumps(r)
             data = pickle.dumps(kwargs['call_state'].data)
-            result = make_result(result=r, call_state_data=data)
+            result = make_result(result=pickled_r, call_state_data=data)
         except Exception as e:
             try:
                 # In case func does something stupid like raising an unpicklable exception

--- a/metafunctions/concurrent.py
+++ b/metafunctions/concurrent.py
@@ -3,13 +3,18 @@ import sys
 from operator import itemgetter
 from multiprocessing import Queue
 import queue
+from collections import namedtuple
+import functools
 
 from metafunctions.core import FunctionMerge
 from metafunctions.core import inject_call_state
 from metafunctions import exceptions
 
+# Result tuple to be sent back from workers. Defined at module level for eas of pickling
+_ConcurrentResult = namedtuple('_ConcurrentResult', 'index result exception')
 
 class ConcurrentMerge(FunctionMerge):
+
     def __init__(self, function_merge: FunctionMerge):
         '''A subclass of FunctionMerge that calls each of its component functions in parallel.
 
@@ -39,17 +44,16 @@ class ConcurrentMerge(FunctionMerge):
         arg_iter, func_iter = self._get_call_iterators(args)
         enumerated_funcs = enumerate(func_iter)
         result_q = Queue()
-        error_q = Queue()
 
         #spawn a child for each function
         children = []
         for arg, (i, f) in zip(arg_iter, enumerated_funcs):
-            child_pid = self._process_in_fork(i, f, result_q, error_q, (arg, ), kwargs)
+            child_pid = self._process_in_fork(i, f, result_q, (arg, ), kwargs)
             children.append(child_pid)
 
         #iterate over any remaining functions for which we have no args
         for i, f in enumerated_funcs:
-            child_pid = self._process_in_fork(i, f, result_q, error_q, (), kwargs)
+            child_pid = self._process_in_fork(i, f, result_q, (), kwargs)
             children.append(child_pid)
 
         #the parent waits for all children to complete
@@ -57,16 +61,13 @@ class ConcurrentMerge(FunctionMerge):
             os.waitpid(pid, 0)
 
         #then retrieves the results
-        try:
-            error = error_q.get_nowait()
-        except queue.Empty:
-            pass
-        else:
-            raise exceptions.ConcurrentException('Caught exception in child process') from error
-
+        results = []
+        #iterate over the result q in sorted order
         result_q.put(None)
-        results = [r[1] for r in sorted(iter(result_q.get, None), key=itemgetter(0))]
-
+        for r in sorted(iter(result_q.get, None), key=itemgetter(0)):
+            if r.exception:
+                raise exceptions.ConcurrentException('Caught exception in child process') from r.exception
+            results.append(r.result)
         return self._merge_func(*results)
 
     def _get_call_iterators(self, args):
@@ -75,7 +76,7 @@ class ConcurrentMerge(FunctionMerge):
     def _call_function(self, f, args:tuple, kwargs:dict):
         return self._function_merge._call_function(f, args, kwargs)
 
-    def _process_in_fork(self, idx, func, result_q, error_q, args, kwargs):
+    def _process_in_fork(self, idx, func, result_q, args, kwargs):
         '''Call self._call_function in a child process. This function returns the ID of the child
         in the parent process, while the child process calls _call_function, puts the results in
         the provided queues, then exits.
@@ -85,19 +86,25 @@ class ConcurrentMerge(FunctionMerge):
             return pid
 
         #here we are the child
+        make_result = functools.partial(_ConcurrentResult,
+                result=None,
+                exception=None,
+                index=idx,
+        )
+
+        result = None
         try:
             r = self._call_function(func, args, kwargs)
         except Exception as e:
-            error_q.put(e)
+            result = make_result(exception=e)
         else:
-            result_q.put((idx, r))
+            result = make_result(result=r)
         finally:
+            result_q.put(result)
             # it's neccesary to explicitly close the result_q and join its background thread here,
             # because the below os._exit won't allow time for any cleanup.
             result_q.close()
-            error_q.close()
             result_q.join_thread()
-            error_q.join_thread()
 
             # This is the one place that the python docs say it's normal to use os._exit. Because
             # this is executed in a child process, calling sys.exit can have unintended

--- a/metafunctions/concurrent.py
+++ b/metafunctions/concurrent.py
@@ -2,7 +2,6 @@ import os
 import sys
 from operator import itemgetter
 from multiprocessing import Queue
-import queue
 from collections import namedtuple
 import functools
 import pickle

--- a/metafunctions/exceptions.py
+++ b/metafunctions/exceptions.py
@@ -1,15 +1,18 @@
-
-
 class MetaFunctionError(Exception):
     pass
 
-class ConcurrentException(MetaFunctionError):
-    pass
 
 class CompositionError(MetaFunctionError, TypeError):
     "An exception that occureds when MetaFunctions are composed incorrectly"
     pass
 
+
 class CallError(MetaFunctionError, TypeError):
     "An exception that occures when a MetaFunction is called incorrectly"
     pass
+
+
+class ConcurrentException(CallError):
+    "Concurrent specific call errors (e.g., things that aren't picklable)"
+    pass
+

--- a/metafunctions/tests/test_concurrent.py
+++ b/metafunctions/tests/test_concurrent.py
@@ -161,7 +161,7 @@ class TestUnit(BaseTestCase):
         with self.assertRaises(ConcurrentException):
             cmp()
 
-    def test_unpickleable_exception(self):
+    def test_unpicklable_exception(self):
         # Don't let child processes crash, even if they do weird things like raise unpickleable
         # exceptions
         @node

--- a/metafunctions/tests/test_concurrent.py
+++ b/metafunctions/tests/test_concurrent.py
@@ -158,9 +158,21 @@ class TestUnit(BaseTestCase):
         # If call_state.data contains something that isn't pickleable, fail gracefully
         bad = [lambda: None] | store('o')
         cmp = concurrent(bad & bad)
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ConcurrentException):
             cmp()
 
+    def test_unpickleable_exception(self):
+        # Don't let child processes crash, even if they do weird things like raise unpickleable
+        # exceptions
+        @node
+        def f():
+            class BadException(Exception):
+                pass
+            raise BadException()
+
+        cmp = concurrent(f+f)
+        with self.assertRaises(ConcurrentException):
+            cmp()
 
 ### Simple Sample Functions ###
 @node

--- a/metafunctions/tests/test_concurrent.py
+++ b/metafunctions/tests/test_concurrent.py
@@ -155,8 +155,6 @@ class TestUnit(BaseTestCase):
         self.assertEqual(cmp('_', call_state=state), ('_ab', '_ba'))
         self.assertDictEqual(state.data, {'ab': '_ab', 'ba': '_ba'})
 
-        called_funcs = state._called_functions
-        self.assertListEqual(called_funcs, [a, b, store, b, a, store])
 
 ### Simple Sample Functions ###
 @node

--- a/metafunctions/tests/test_concurrent.py
+++ b/metafunctions/tests/test_concurrent.py
@@ -155,6 +155,12 @@ class TestUnit(BaseTestCase):
         self.assertEqual(cmp('_', call_state=state), ('_ab', '_ba'))
         self.assertDictEqual(state.data, {'ab': '_ab', 'ba': '_ba'})
 
+        # If call_state.data contains something that isn't pickleable, fail gracefully
+        bad = [lambda: None] | store('o')
+        cmp = concurrent(bad & bad)
+        with self.assertRaises(AttributeError):
+            cmp()
+
 
 ### Simple Sample Functions ###
 @node

--- a/metafunctions/tests/test_concurrent.py
+++ b/metafunctions/tests/test_concurrent.py
@@ -161,6 +161,17 @@ class TestIntegration(BaseTestCase):
         with self.assertRaises(ConcurrentException):
             cmp()
 
+    def test_unpicklable_return(self):
+        # Concurrent can't handle functions that return unpicklable objects. Raise a descriptive
+        # exception
+        @node
+        def f():
+            return lambda:None
+
+        cmp = concurrent(f & f)
+        with self.assertRaises(ConcurrentException):
+            cmp()
+
     def test_unpicklable_exception(self):
         # Don't let child processes crash, even if they do weird things like raise unpickleable
         # exceptions

--- a/metafunctions/tests/test_concurrent.py
+++ b/metafunctions/tests/test_concurrent.py
@@ -167,7 +167,6 @@ class TestIntegration(BaseTestCase):
         @node
         def f():
             return lambda:None
-
         cmp = concurrent(f & f)
         with self.assertRaises(ConcurrentException):
             cmp()
@@ -197,10 +196,12 @@ class TestIntegration(BaseTestCase):
         # detect errors that may be squelched by the interactions of multiple processes
 
         # Re-run all tests with fork patched
-        for test_name in (t for t in dir(self) if t.startswith('test_') and t != 'test_no_fork'):
+        this_test = self.id().split('.')[-1]
+        for test_name in (t for t in dir(self) if t.startswith('test_') and t != this_test):
             method = getattr(self, test_name)
             print('calling, ', method)
-            method()
+            with self.subTest(name=test_name):
+                method()
 
 
 ### Simple Sample Functions ###


### PR DESCRIPTION
Concurrent now re-integrates the call_state.data dictionary from each child process, so that `store` and `recall` continue to work in concurrent `FunctionMerges`. 

This also adds some exception handling for cases where functions return things (or raise exceptions) that aren't picklable. This after I found some edge cases where my tests would deadlock/forkbomb.