### PR TITLE
Tox travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - TOXENV=py37
 install:
   - pip install codecov
+  - pip install tox
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "3.6"
 env:
-  - TOXENV=py34
   - TOXENV=py35
   - TOXENV=py36
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   - TOXENV=py34
   - TOXENV=py35
   - TOXENV=py36
-  - TOXENV=py37
 install:
   - pip install -U tox codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "3.6"
-  - 3.5
 env:
   - TOXENV=py34
   - TOXENV=py35
@@ -14,3 +13,10 @@ script:
 
 after_success:
   - codecov
+
+addons: #Added to get python 3.5
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ env:
   - TOXENV=py36
   - TOXENV=py37
 install:
-  - pip install codecov
-  - pip install tox
+  - pip install -U tox codecov
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   - TOXENV=py37
 install:
   - pip install codecov
-  - pip install -r requirements.txt
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: python
 python:
   - "3.6"
-  - "3.7-dev"
+env:
+  - TOXENV=py34
+  - TOXENV=py35
+  - TOXENV=py36
+  - TOXENV=py37
 install:
   - pip install codecov
   - pip install -r requirements.txt
 
 script:
-  - coverage run -pm unittest discover
-  - coverage combine
+  - tox
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.6"
+  - 3.5
 env:
   - TOXENV=py34
   - TOXENV=py35

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,53 @@
+# What Python version is installed where:
+# http://www.appveyor.com/docs/installed-software#python
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python34"
+      TOX_ENV: "py34"
+
+    - PYTHON: "C:\\Python34-x64"
+      TOX_ENV: "py34"
+
+    - PYTHON: "C:\\Python35"
+      TOX_ENV: "py35"
+
+    - PYTHON: "C:\\Python35-x64"
+      TOX_ENV: "py35"
+
+    - PYTHON: "C:\\Python36"
+      TOX_ENV: "py36"
+
+    - PYTHON: "C:\\Python36-x64"
+      TOX_ENV: "py36"
+
+init:
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+  - "git config --system http.sslcainfo \"C:\\Program Files\\Git\\mingw64\\ssl\\certs\\ca-bundle.crt\""
+  - "%PYTHON%/python -V"
+  - "%PYTHON%/python -c \"import struct;print(8 * struct.calcsize(\'P\'))\""
+
+install:
+  - "%PYTHON%/Scripts/easy_install -U pip"
+  - "%PYTHON%/Scripts/pip install tox"
+  - "%PYTHON%/Scripts/pip install wheel"
+
+build: false  # Not a C# project, build stuff at the test step instead.
+
+test_script:
+  - "%PYTHON%/Scripts/tox -e %TOX_ENV%"
+
+after_test:
+  - "%PYTHON%/python setup.py bdist_wheel"
+  - ps: "ls dist"
+
+on_success:
+    # Report coverage results to codecov.io
+    # and export tox environment variables
+    - "%PYTHON%/Scripts/pip install codecov"
+    - set OS=WINDOWS
+    - "%PYTHON%/Scripts/codecov -e TOX_ENV OS"
+
+artifacts:
+  - path: dist\*
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,6 @@
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python34"
-      TOX_ENV: "py34"
-
-    - PYTHON: "C:\\Python34-x64"
-      TOX_ENV: "py34"
-
     - PYTHON: "C:\\Python35"
       TOX_ENV: "py35"
 

--- a/metafunctions.wpr
+++ b/metafunctions.wpr
@@ -10,7 +10,8 @@ proj.directory-list = [{'dirloc': loc('metafunctions'),
                         'include_hidden': False,
                         'recursive': True,
                         'watch_for_changes': True}]
-proj.file-list = [loc('setup.py')]
+proj.file-list = [loc('setup.py'),
+                  loc('tox.ini')]
 proj.file-type = 'shared'
 proj.launch-config = {loc('setup.py'): ('project',
         (u'sdist\n',

--- a/metafunctions.wpr
+++ b/metafunctions.wpr
@@ -10,7 +10,8 @@ proj.directory-list = [{'dirloc': loc('metafunctions'),
                         'include_hidden': False,
                         'recursive': True,
                         'watch_for_changes': True}]
-proj.file-list = [loc('setup.py'),
+proj.file-list = [loc('appveyor.yml'),
+                  loc('setup.py'),
                   loc('tox.ini')]
 proj.file-type = 'shared'
 proj.launch-config = {loc('setup.py'): ('project',

--- a/metafunctions/api.py
+++ b/metafunctions/api.py
@@ -50,7 +50,7 @@ def star(meta_function: MetaFunction) -> MetaFunction:
     '''
     fname = str(meta_function)
     #This convoluted inline `if` just decides whether we should add brackets or not.
-    @node(name=f'star{fname}' if fname.startswith('(') else f'star({fname})')
+    @node(name='star{}'.format(fname) if fname.startswith('(') else 'star({})'.format(fname))
     @functools.wraps(meta_function)
     def wrapper(args, **kwargs):
         return meta_function(*args, **kwargs)
@@ -59,7 +59,7 @@ def star(meta_function: MetaFunction) -> MetaFunction:
 
 def store(key):
     '''Store the received output in the meta data dictionary under the given key.'''
-    @node(name=f"store('{key}')")
+    @node(name="store('{}')".format(key))
     @bind_call_state
     def storer(call_state, val):
         call_state.data[key] = val
@@ -71,7 +71,7 @@ def recall(key, from_call_state: CallState=None):
     '''Retrieve the given key from the meta data dictionary. Optionally, use `from_call_state` to
     specify a different call_state than the current one.
     '''
-    @node(name=f"recall('{key}')")
+    @node(name="recall('{}')".format(key))
     @bind_call_state
     def recaller(call_state, *_):
         if from_call_state:
@@ -127,7 +127,7 @@ def locate_error(meta_function: MetaFunction,
 
             if use_color:
                 location = util.color_highlights(location)
-            detailed_message = (f"{str(e)} \n\nOccured in the following function: {location}")
+            detailed_message = ("{0!s} \n\nOccured in the following function: {1}".format(e, location))
             new_e = type(e)(detailed_message).with_traceback(e.__traceback__)
             new_e.__cause__ = e.__cause__
         raise new_e

--- a/metafunctions/api.py
+++ b/metafunctions/api.py
@@ -1,11 +1,8 @@
 '''
 Utility functions for use in function pipelines.
 '''
-import sys
-import re
 import functools
 import typing as tp
-import os
 
 from metafunctions.core import MetaFunction
 from metafunctions.core import SimpleFunction
@@ -70,13 +67,13 @@ def store(key):
     return storer
 
 
-def recall(key, from_call_state:CallState=None):
+def recall(key, from_call_state: CallState=None):
     '''Retrieve the given key from the meta data dictionary. Optionally, use `from_call_state` to
     specify a different call_state than the current one.
     '''
     @node(name=f"recall('{key}')")
     @bind_call_state
-    def recaller(call_state, val):
+    def recaller(call_state, *_):
         if from_call_state:
             return from_call_state.data[key]
         return call_state.data[key]

--- a/metafunctions/api.py
+++ b/metafunctions/api.py
@@ -7,8 +7,6 @@ import functools
 import typing as tp
 import os
 
-import colors
-
 from metafunctions.core import MetaFunction
 from metafunctions.core import SimpleFunction
 from metafunctions.core import FunctionMerge
@@ -110,7 +108,6 @@ def mmap(function: tp.Callable, operator: tp.Callable=operators.concat) -> Merge
 
 
 def locate_error(meta_function: MetaFunction,
-                 color=colors.red,
                  use_color=util.system_supports_color()) -> SimpleFunction:
     '''
     Wrap the given MetaFunction with an error handler that adds location information to any

--- a/metafunctions/core/base.py
+++ b/metafunctions/core/base.py
@@ -29,7 +29,7 @@ class MetaFunction(metaclass=abc.ABCMeta):
         '''Call the functions contained in this MetaFunction'''
 
     def __str__(self):
-        return f'({f" {self._function_join_str} ".join(str(f) for f in self.functions)})'
+        return '({})'.format(" {} ".format(self._function_join_str).join(str(f) for f in self.functions))
 
     @property
     def functions(self):
@@ -129,7 +129,7 @@ class FunctionChain(MetaFunction):
         return result
 
     def __repr__(self):
-        return f'{self.__class__.__name__}{self.functions}'
+        return '{self.__class__.__name__}{self.functions}'.format(self=self)
 
     @classmethod
     def combine(cls, *funcs):
@@ -197,7 +197,7 @@ class FunctionMerge(MetaFunction):
         return self._merge_func(*results)
 
     def __repr__(self):
-        return f'{self.__class__.__name__}({self._merge_func}, {self.functions})'
+        return '{self.__class__.__name__}({self._merge_func}, {self.functions})'.format(self=self)
 
     @classmethod
     def combine(cls, merge_func: tp.Callable, *funcs, function_join_str=None):
@@ -224,9 +224,8 @@ class FunctionMerge(MetaFunction):
         args_iter = iter(args)
         func_iter = iter(self.functions)
         if len(args) > len(self.functions):
-            raise exceptions.CallError(
-                    f'{self} takes 1 or <= {len(self.functions)} '
-                    f'arguments, but {len(args)} were given')
+            raise exceptions.CallError('{} takes 1 or <= {} arguments, but {} were given'.format(
+                self, len(self.functions), len(args)))
         if len(args) == 1:
             args_iter = itertools.repeat(next(args_iter))
 
@@ -262,7 +261,7 @@ class SimpleFunction(MetaFunction):
         return self._function(*args, **kwargs)
 
     def __repr__(self):
-        return f'{self.__class__.__name__}({self.functions[0]!r})'
+        return '{self.__class__.__name__}({self.functions[0]!r})'.format(self=self)
 
     def __str__(self):
         return self._name
@@ -283,7 +282,7 @@ class DeferredValue(SimpleFunction):
         return self._value
 
     def __repr__(self):
-        return f'{self.__class__.__name__}({self._value!r})'
+        return '{self.__class__.__name__}({self._value!r})'.format(self=self)
 
     @property
     def functions(self):

--- a/metafunctions/core/call_state.py
+++ b/metafunctions/core/call_state.py
@@ -1,5 +1,3 @@
-import re
-
 from collections import namedtuple, defaultdict, OrderedDict
 from metafunctions import util
 

--- a/metafunctions/core/call_state.py
+++ b/metafunctions/core/call_state.py
@@ -1,7 +1,5 @@
 import re
 
-import colors
-
 from collections import namedtuple, defaultdict, OrderedDict
 from metafunctions import util
 

--- a/metafunctions/core/concurrent.py
+++ b/metafunctions/core/concurrent.py
@@ -10,7 +10,8 @@ from metafunctions.core import manage_call_state
 from metafunctions import exceptions
 
 # Result tuple to be sent back from workers. Defined at module level for eas of pickling
-_ConcurrentResult = namedtuple('_ConcurrentResult', 'index result call_state_data exception location')
+_ConcurrentResult = namedtuple('_ConcurrentResult',
+                               'index result call_state_data exception location')
 
 class ConcurrentMerge(FunctionMerge):
 
@@ -26,14 +27,14 @@ class ConcurrentMerge(FunctionMerge):
             raise exceptions.CompositionError(f'{type(self)} can only upgrade FunctionMerges')
 
         super().__init__(
-                function_merge._merge_func,
-                function_merge._functions,
-                function_merge._function_join_str)
+            function_merge._merge_func,
+            function_merge._functions,
+            function_merge._function_join_str)
         self._function_merge = function_merge
 
     def __str__(self):
         merge_name = str(self._function_merge)
-        return f'concurrent{merge_name}' if merge_name.startswith('(') else f'concurrent({merge_name})'
+        return (f'concurrent{merge_name}' if merge_name.startswith('(') else f'concurrent({merge_name})')
 
     @manage_call_state
     def __call__(self, *args, **kwargs):
@@ -66,7 +67,7 @@ class ConcurrentMerge(FunctionMerge):
         for r in sorted(iter(result_q.get, None), key=itemgetter(0)):
             if r.exception:
                 raise exceptions.ConcurrentException(
-                        'Caught exception in child process', location=r.location) from pickle.loads(r.exception)
+                    'Caught exception in child process', location=r.location) from pickle.loads(r.exception)
             kwargs['call_state'].data.update(pickle.loads(r.call_state_data))
             results.append(pickle.loads(r.result))
         return self._merge_func(*results)
@@ -124,4 +125,3 @@ class ConcurrentMerge(FunctionMerge):
             # consequences. e.g., anything above this that catches the resulting SystemExit can
             # cause the child process to stay alive. the unittest framework does this.
             os._exit(0)
-

--- a/metafunctions/core/concurrent.py
+++ b/metafunctions/core/concurrent.py
@@ -24,7 +24,11 @@ class ConcurrentMerge(FunctionMerge):
             #This check is necessary because functools.wraps will copy FunctionMerge attributes to
             #objects that are not FunctionMerges, so this init will succeed, then result in errors
             #at call time.
-            raise exceptions.CompositionError('{} can only upgrade FunctionMerges'.format(type(self)))
+            raise exceptions.CompositionError(
+                '{} can only upgrade FunctionMerges'.format(type(self)))
+        if not hasattr(os, 'fork'):
+            raise exceptions.CompositionError(
+                '{} requires os.fork, and thus is only available on unix'.format(type(self).__name__))
 
         super().__init__(
             function_merge._merge_func,

--- a/metafunctions/core/concurrent.py
+++ b/metafunctions/core/concurrent.py
@@ -24,7 +24,7 @@ class ConcurrentMerge(FunctionMerge):
             #This check is necessary because functools.wraps will copy FunctionMerge attributes to
             #objects that are not FunctionMerges, so this init will succeed, then result in errors
             #at call time.
-            raise exceptions.CompositionError(f'{type(self)} can only upgrade FunctionMerges')
+            raise exceptions.CompositionError('{} can only upgrade FunctionMerges'.format(type(self)))
 
         super().__init__(
             function_merge._merge_func,
@@ -34,7 +34,8 @@ class ConcurrentMerge(FunctionMerge):
 
     def __str__(self):
         merge_name = str(self._function_merge)
-        return (f'concurrent{merge_name}' if merge_name.startswith('(') else f'concurrent({merge_name})')
+        return ('concurrent{}'.format(merge_name) if merge_name.startswith('(')
+                else 'concurrent({})'.format(merge_name))
 
     @manage_call_state
     def __call__(self, *args, **kwargs):
@@ -110,7 +111,7 @@ class ConcurrentMerge(FunctionMerge):
                 pickled_exception = pickle.dumps(e)
             except AttributeError:
                 pickled_exception = pickle.dumps(
-                        AttributeError(f'Unplicklable exception raised in {func}'))
+                        AttributeError('Unplicklable exception raised in {}'.format(func)))
             result = make_result(exception=pickled_exception,
                     location=kwargs['call_state'].highlight_active_function())
         finally:

--- a/metafunctions/exceptions.py
+++ b/metafunctions/exceptions.py
@@ -16,7 +16,7 @@ class CallError(MetaFunctionError, TypeError):
         return '{}({}, {})'.format(
             self.__class__.__name__,
             self.args,
-            f"location='{self.location}'" if self.location else '')
+            "location='{}'".format(self.location) if self.location else '')
 
 class ConcurrentException(CallError):
     "Concurrent specific call errors (e.g., things that aren't picklable)"

--- a/metafunctions/map.py
+++ b/metafunctions/map.py
@@ -31,7 +31,7 @@ class MergeMap(FunctionMerge):
         return f(*args[0], **kwargs)
 
     def __str__(self):
-        return f'mmap({self.functions[0]!s})'
+        return 'mmap({self.functions[0]!s})'.format(self=self)
 
     def __repr__(self):
-        return f'{self.__class__.__name__}({self.functions[0]}, merge_function={self._merge_func})'
+        return '{self.__class__.__name__}({self.functions[0]}, merge_function={self._merge_func})'.format(self=self)

--- a/metafunctions/tests/test_at_operator.py
+++ b/metafunctions/tests/test_at_operator.py
@@ -19,7 +19,7 @@ class TestUnit(BaseTestCase):
         cmp = a @ b
         self.assertEqual(str(cmp), '(a | star(b))')
         self.assertEqual(repr(cmp),
-                f"FunctionChain{(a, cmp.functions[1])}")
+                "FunctionChain{}".format((a, cmp.functions[1])))
 
         cmp = a | a @ b * 5 / 7 | b & b @ a
         self.assertEqual(str(cmp), '(a | (((a | star(b)) * 5) / 7) | (b & (b | star(a))))')
@@ -30,7 +30,7 @@ class TestUnit(BaseTestCase):
         cmp = a @ (b&c)
         self.assertEqual(str(cmp), '(a | star(b & c))')
         self.assertEqual(repr(cmp),
-                             f'FunctionChain({a!r}, SimpleFunction({cmp._functions[1]._function}))')
+            'FunctionChain({0!r}, SimpleFunction({1}))'.format(a, cmp._functions[1]._function))
 
     def test_upgrade_merge(self):
         aabbcc = (a & b & c) @ (a&b&c)

--- a/metafunctions/tests/test_concurrent.py
+++ b/metafunctions/tests/test_concurrent.py
@@ -1,4 +1,6 @@
+import platform
 import operator
+import unittest
 from unittest import mock
 import functools
 
@@ -19,6 +21,7 @@ from metafunctions.core import CallState
 from metafunctions.exceptions import ConcurrentException, CompositionError, CallError
 
 
+@unittest.skipIf(platform.system() == 'Windows', "Concurrent isn't supported on windows")
 class TestIntegration(BaseTestCase):
     def test_basic(self):
         ab = a + b
@@ -203,4 +206,9 @@ class TestIntegration(BaseTestCase):
             with self.subTest(name=test_name):
                 method()
 
-
+    @mock.patch('metafunctions.core.concurrent.hasattr', return_value=False)
+    def test_windows(self, mock_hasattr):
+        with self.assertRaises(CompositionError) as e:
+            concurrent(a+a)
+        self.assertEqual(str(e.exception),
+            'ConcurrentMerge requires os.fork, and thus is only available on unix')

--- a/metafunctions/tests/test_concurrent.py
+++ b/metafunctions/tests/test_concurrent.py
@@ -38,8 +38,8 @@ class TestIntegration(BaseTestCase):
             cmp()
         self.assertIsInstance(e.exception.__cause__, ZeroDivisionError)
         self.assertEqual(str(e.exception),
-                f'Caught exception in child process \n\nOccured in the following function: '
-                f'(0 | concurrent({colors.red("->fail<-")} - fail))')
+                'Caught exception in child process \n\nOccured in the following function: '
+                '(0 | concurrent({} - fail))'.format(colors.red("->fail<-")))
         self.assertIsInstance(e.exception.__cause__, ZeroDivisionError)
 
     def test_consistent_meta(self):
@@ -104,9 +104,10 @@ class TestIntegration(BaseTestCase):
         cab = ConcurrentMerge(a + b)
         cmap = concurrent(mmap(a))
 
-        self.assertEqual(repr(cab), f'ConcurrentMerge({operator.add}, ({repr(a)}, {repr(b)}))')
-        self.assertEqual(str(cab), f'concurrent(a + b)')
-        self.assertEqual(str(cmap), f'concurrent(mmap(a))')
+        self.assertEqual(repr(cab), 'ConcurrentMerge({0}, ({1!r}, {2!r}))'.format(
+            operator.add, a, b))
+        self.assertEqual(str(cab), 'concurrent(a + b)')
+        self.assertEqual(str(cmap), 'concurrent(mmap(a))')
 
     def test_basic_map(self):
         # We can upgrade maps to run in parallel

--- a/metafunctions/tests/test_deferred_value.py
+++ b/metafunctions/tests/test_deferred_value.py
@@ -12,7 +12,7 @@ class TestUnit(BaseTestCase):
     def test_str_repr(self):
         a = object()
         b = DeferredValue(a)
-        self.assertEqual(repr(b), f'DeferredValue({repr(a)})')
+        self.assertEqual(repr(b), 'DeferredValue({0!r})'.format(a))
         self.assertEqual(str(DeferredValue(5)), '5')
         self.assertEqual(repr(DeferredValue('a')), "DeferredValue('a')")
 

--- a/metafunctions/tests/test_function_chain.py
+++ b/metafunctions/tests/test_function_chain.py
@@ -10,7 +10,7 @@ class TestUnit(BaseTestCase):
     def test_str(self):
         c = FunctionChain(a, b, l)
         self.assertEqual(str(c), '(a | b | <lambda>)')
-        self.assertEqual(repr(c), f'FunctionChain{(a,b,l)}')
+        self.assertEqual(repr(c), 'FunctionChain{}'.format((a,b,l)))
 
     def test_call(self):
         c = FunctionChain(a, b, l)

--- a/metafunctions/tests/test_function_merge.py
+++ b/metafunctions/tests/test_function_merge.py
@@ -13,7 +13,7 @@ class TestUnit(BaseTestCase):
     def test_str(self):
         cmp = FunctionMerge(operator.add, (a, b))
         self.assertEqual(str(cmp), '(a + b)')
-        self.assertEqual(repr(cmp), f'FunctionMerge({operator.add}, {(a, b)})')
+        self.assertEqual(repr(cmp), 'FunctionMerge({}, {})'.format(operator.add, (a, b)))
 
     def test_call(self):
         cmp = FunctionMerge(operator.add, (a, b))
@@ -39,7 +39,7 @@ class TestUnit(BaseTestCase):
         cmp = FunctionMerge(my_concat, (a, a, a, a))
         self.assertEqual(cmp('_'), '_a_a_a_a')
 
-        self.assertEqual(str(cmp), f'(a {my_concat} a {my_concat} a {my_concat} a)')
+        self.assertEqual(str(cmp), '(a {m} a {m} a {m} a)'.format(m=my_concat))
 
         d = FunctionMerge(my_concat, (b, b), function_join_str='q')
         self.assertEqual(str(d), '(b q b)')
@@ -51,7 +51,7 @@ class TestUnit(BaseTestCase):
 
         self.assertTupleEqual(cmp('_'), ('_a', '_a', 'sweet as'))
         self.assertEqual(str(cmp), "(a & a & 'sweet as')")
-        self.assertEqual(repr(cmp), f"FunctionMerge({concat}, {(a, a, cmp._functions[-1])})")
+        self.assertEqual(repr(cmp), "FunctionMerge({}, {})".format(concat, (a, a, cmp._functions[-1])))
 
         #__rand__ works too
         a_ = 'sweet as' & a
@@ -71,21 +71,21 @@ class TestUnit(BaseTestCase):
         #operator.add only takes two args). I'm just using to combine for test purposes.
         abba = FunctionMerge.combine(operator.add, add, also_add)
         self.assertEqual(str(abba), '(a + b + b + a)')
-        self.assertEqual(repr(abba), f"FunctionMerge({operator.add}, {(a, b, b, a)})")
+        self.assertEqual(repr(abba), "FunctionMerge({}, {})".format(operator.add, (a, b, b, a)))
 
         ab_ba = FunctionMerge.combine(operator.sub, add, also_add)
         self.assertEqual(str(ab_ba), '((a + b) - (b + a))')
-        self.assertEqual(repr(ab_ba), f"FunctionMerge({operator.sub}, {(add, also_add)})")
+        self.assertEqual(repr(ab_ba), "FunctionMerge({}, {})".format(operator.sub, (add, also_add)))
 
         abab = FunctionMerge.combine(operator.add, add, div)
         self.assertEqual(str(abab), '(a + b + (a / b))')
-        self.assertEqual(repr(abab), f"FunctionMerge({operator.add}, {(a, b, div)})")
+        self.assertEqual(repr(abab), "FunctionMerge({}, {})".format(operator.add, (a, b, div)))
 
         def custom():
             pass
         abba_ = FunctionMerge.combine(custom, add, also_add, function_join_str='<>')
         self.assertEqual(str(abba_), '((a + b) <> (b + a))')
-        self.assertEqual(repr(abba_), f"FunctionMerge({custom}, {(add, also_add)})")
+        self.assertEqual(repr(abba_), "FunctionMerge({}, {})".format(custom, (add, also_add)))
 
         def my_concat(*args):
             return ''.join(args)
@@ -93,7 +93,7 @@ class TestUnit(BaseTestCase):
         aa = FunctionMerge(my_concat, (a, a), function_join_str='q')
         bbaa = FunctionMerge.combine(my_concat, bb, aa, function_join_str='q')
         self.assertEqual(str(bbaa), '(b q b q a q a)')
-        self.assertEqual(repr(bbaa), f"FunctionMerge({my_concat}, {(b, b, a, a)})")
+        self.assertEqual(repr(bbaa), "FunctionMerge({}, {})".format(my_concat, (b, b, a, a)))
 
     def test_len_mismatch(self):
         # If len(inputs) <= len(functions), call remaining functions with  no args.

--- a/metafunctions/tests/test_imports.py
+++ b/metafunctions/tests/test_imports.py
@@ -1,6 +1,5 @@
 import unittest
 import random
-import importlib
 
 class TestUnit(unittest.TestCase):
     def test_api_imports(self):

--- a/metafunctions/tests/test_imports.py
+++ b/metafunctions/tests/test_imports.py
@@ -7,4 +7,4 @@ class TestUnit(unittest.TestCase):
                           'mmap', 'locate_error']
         random.shuffle(expected_names)
         for name in expected_names:
-            exec(f'from metafunctions import {name}')
+            exec('from metafunctions import {}'.format(name))

--- a/metafunctions/tests/test_map.py
+++ b/metafunctions/tests/test_map.py
@@ -40,12 +40,12 @@ class TestIntegration(BaseTestCase):
     def test_auto_meta(self):
         mapsum = mmap(sum)
         self.assertEqual(mapsum([[1, 2], [3, 4]]), (3, 7))
-        self.assertEqual(str(mapsum), f'mmap(sum)')
+        self.assertEqual(str(mapsum), 'mmap(sum)')
 
     def test_str_repr(self):
         m = MergeMap(a)
         self.assertEqual(str(m), 'mmap(a)')
-        self.assertEqual(repr(m), f'MergeMap(a, merge_function={operators.concat})')
+        self.assertEqual(repr(m), 'MergeMap(a, merge_function={})'.format(operators.concat))
 
     def test_loop(self):
         cmp = (b & c & 'stoke') | mmap(a)

--- a/metafunctions/tests/test_pipe.py
+++ b/metafunctions/tests/test_pipe.py
@@ -62,7 +62,7 @@ class TestIntegration(BaseTestCase):
         self.assertEqual(str(cmp), "(a + 'f')")
         self.assertEqual(repr(cmp),
                 "FunctionMerge(<built-in function add>, "
-                f"(SimpleFunction({repr(a._function)}), DeferredValue('f')))")
+                "(SimpleFunction({0!r}), DeferredValue('f')))".format(a._function))
 
     def test_non_callable_composition(self):
         '''
@@ -237,7 +237,7 @@ class TestIntegration(BaseTestCase):
             return x + 'f'
 
         fn = node(f+'sup')
-        self.assertEqual(repr(fn), f"SimpleFunction({(f+'sup')!r})")
+        self.assertEqual(repr(fn), "SimpleFunction({0!r})".format((f+'sup')))
         self.assertEqual(str(fn), "(f + 'sup')")
         abcf = a | b | c | fn
 

--- a/metafunctions/tests/test_simple_function.py
+++ b/metafunctions/tests/test_simple_function.py
@@ -12,7 +12,7 @@ class TestUnit(BaseTestCase):
         self.assertEqual(l('_'), '_l')
 
     def test_str(self):
-        self.assertEqual(repr(a), f'SimpleFunction({repr(a._function)})')
+        self.assertEqual(repr(a), 'SimpleFunction({0!r})'.format(a._function))
         self.assertEqual(str(a), 'a')
 
 

--- a/metafunctions/tests/test_star.py
+++ b/metafunctions/tests/test_star.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 from metafunctions.api import node, star, concurrent
 from metafunctions.tests.simple_nodes import *
@@ -48,6 +49,7 @@ class TestUnit(BaseTestCase):
         #reprs remain the same
         self.assertEqual(repr(star_a), 'SimpleFunction({})'.format(star_a._function))
 
+    @unittest.skipUnless(hasattr(os, 'fork'), "Concurent isn't available on windows")
     def test_concurrent(self):
         # Concurrent and star can work together, although this organization no longer makes sense
         with self.assertRaises(exceptions.CompositionError):

--- a/metafunctions/tests/test_star.py
+++ b/metafunctions/tests/test_star.py
@@ -43,10 +43,10 @@ class TestUnit(BaseTestCase):
         self.assertEqual(str(chain_star), 'star(a | b)')
 
         #You can technically apply star to a regular function, and it'll become a SimpleFunction
-        self.assertEqual(str(h), f'star({h._function.__closure__[0].cell_contents})')
+        self.assertEqual(str(h), 'star({})'.format(h._function.__closure__[0].cell_contents))
 
         #reprs remain the same
-        self.assertEqual(repr(star_a), f'SimpleFunction({star_a._function})')
+        self.assertEqual(repr(star_a), 'SimpleFunction({})'.format(star_a._function))
 
     def test_concurrent(self):
         # Concurrent and star can work together, although this organization no longer makes sense

--- a/metafunctions/tests/test_util.py
+++ b/metafunctions/tests/test_util.py
@@ -1,13 +1,9 @@
-from unittest import mock
-import functools
-
 import colors
 
 from metafunctions.tests.util import BaseTestCase
 from metafunctions.tests.simple_nodes import *
-from metafunctions.api import store, recall, node, bind_call_state, locate_error, mmap
+from metafunctions.api import node, locate_error
 from metafunctions import util
-from metafunctions.core import SimpleFunction, CallState
 
 
 class TestUnit(BaseTestCase):

--- a/metafunctions/tests/test_util.py
+++ b/metafunctions/tests/test_util.py
@@ -42,4 +42,6 @@ class TestUnit(BaseTestCase):
 
     def test_color_highlights(self):
         s = 'a ->test<- string ->for<- highlight'
-        self.assertEqual(util.color_highlights(s), f'a {colors.red("->test<-")} string {colors.red("->for<-")} highlight')
+        self.assertEqual(util.color_highlights(s),
+                         'a {} string {} highlight'.format(colors.red("->test<-"),
+                                                           colors.red("->for<-")))

--- a/metafunctions/tests/util.py
+++ b/metafunctions/tests/util.py
@@ -31,6 +31,6 @@ class BaseTestCase(unittest.TestCase):
 
     def _formatMessage(self, msg, standardMsg):
         msg = msg or ''
-        return super()._formatMessage(msg=f'{msg} (seed: {self.seed})', standardMsg=standardMsg)
+        return super()._formatMessage(msg='{} (seed: {})'.format(msg, self.seed), standardMsg=standardMsg)
 
 

--- a/metafunctions/util.py
+++ b/metafunctions/util.py
@@ -43,7 +43,7 @@ def replace_nth(string, substring, occurance_index: int, new_substring):
     '''
     escaped = re.escape(substring)
     # There's probably a better regex for this.
-    regex = f"((?:.*?{escaped}.*?){{{occurance_index-1}}}.*?){escaped}(.*$)"
+    regex = "((?:.*?{0}.*?){{{1}}}.*?){0}(.*$)".format(escaped, occurance_index-1)
     return re.sub(regex, fr'\1{new_substring}\2', string)
 
 

--- a/metafunctions/util.py
+++ b/metafunctions/util.py
@@ -4,7 +4,14 @@ import sys
 import re
 import contextlib
 
-import colors
+DEFAULT_HIGHLIGHT_COLOR = None
+try:
+    import colors
+except ImportError:
+    _HAS_COLORS = False
+else:
+    DEFAULT_HIGHLIGHT_COLOR = colors.red
+    _HAS_COLORS = True
 
 HIGHLIGHT_TEMPLATE = '->{}<-'
 
@@ -12,7 +19,7 @@ def highlight(string):
     return HIGHLIGHT_TEMPLATE.format(string)
 
 _color_regex = re.compile(HIGHLIGHT_TEMPLATE.format('.*?'))
-def color_highlights(string, color=colors.red):
+def color_highlights(string, color=DEFAULT_HIGHLIGHT_COLOR):
     '''Color all highlights'''
     for substr in _color_regex.findall(string):
         string = string.replace(substr, color(substr))
@@ -27,7 +34,7 @@ def system_supports_color():
     supported_platform = plat != 'Pocket PC' and (plat != 'win32' or 'ANSICON' in os.environ)
     # isatty is not always implemented, #6223.
     is_a_tty = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
-    if not supported_platform or not is_a_tty:
+    if not _HAS_COLORS or not supported_platform or not is_a_tty:
         return False
     return True
 

--- a/metafunctions/util.py
+++ b/metafunctions/util.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import re
-import contextlib
 
 DEFAULT_HIGHLIGHT_COLOR = None
 try:

--- a/metafunctions/util.py
+++ b/metafunctions/util.py
@@ -44,6 +44,6 @@ def replace_nth(string, substring, occurance_index: int, new_substring):
     escaped = re.escape(substring)
     # There's probably a better regex for this.
     regex = "((?:.*?{0}.*?){{{1}}}.*?){0}(.*$)".format(escaped, occurance_index-1)
-    return re.sub(regex, fr'\1{new_substring}\2', string)
+    return re.sub(regex, r'\1{}\2'.format(new_substring), string)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-ansicolors>=1.1.8

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,6 @@ import metafunctions
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(here, 'requirements.txt')) as f:
-    requirements = f.readlines()
-
 
 class UploadCommand(Command):
     """
@@ -75,7 +72,7 @@ setup(
     keywords='functional-programming function-composition',
     packages=find_packages(),
     test_suite='metafunctions.tests',
-    install_requires=requirements,
+    install_requires='ansicolors>=1.1.8',
     # $ setup.py publish support.
     cmdclass={
         'upload': UploadCommand,

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py34, py35, py36
+envlist = py34, py35, py36, py3.7
 
 [testenv]
 deps =  coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py32, py33, py34, py35, py36, pypy, jython
+
+[testenv]
+commands = {envpython} setup.py test
+deps = ansicolors

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-#envlist = py32, py33, py34, py35, py36, pypy, jython
-envlist = py36
+envlist = py34, py35, py36
 
 [testenv]
 commands = python -m unittest discover

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py32, py33, py34, py35, py36, pypy, jython
+#envlist = py32, py33, py34, py35, py36, pypy, jython
+envlist = py36
 
 [testenv]
 commands = python -m unittest discover
-deps =
-    -rrequirements.txt
+

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,8 @@
 envlist = py34, py35, py36
 
 [testenv]
-commands = python -m unittest discover
+deps =  coverage
+commands = 
+    coverage run -pm unittest discover
+    coverage combine
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, pypy, jython
+envlist = py27, py32, py33, py34, py35, py36, pypy, jython
 
 [testenv]
-commands = {envpython} setup.py test
-deps = ansicolors
+commands = python -m unittest discover
+deps =
+    -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py34, py35, py36, py3.7
+envlist = py34, py35, py36
 
 [testenv]
 deps =  coverage

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py34, py35, py36
+envlist = py35, py36
 
 [testenv]
 deps =  coverage
-commands = 
+commands =
     coverage run -pm unittest discover
     coverage combine
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,9 @@
 envlist = py35, py36
 
 [testenv]
-deps =  coverage
+deps =
+    coverage
+    ansicolors
 commands =
     coverage run -pm unittest discover
     coverage combine


### PR DESCRIPTION
This adds support for python 3.5+ (previously metafunctions required 3.6+), and windows. `concurrent` is still not supported on windows, but the rest of the library will work.